### PR TITLE
Add exclude paths configuration for annotation driver

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -125,6 +125,7 @@ extensions:
 
 orm.annotations:
     paths: [] # define paths for Entities 
+    excludePaths: [] # these paths will be excluded 
     ignore: [] # ignored annotations
     cache: Doctrine\Common\Cache\FilesystemCache
     cacheDir: '%tempDir%/cache/Doctrine.Annotations'

--- a/src/DI/OrmAnnotationsExtension.php
+++ b/src/DI/OrmAnnotationsExtension.php
@@ -22,6 +22,7 @@ class OrmAnnotationsExtension extends CompilerExtension
 	/** @var mixed[] */
 	public $defaults = [
 		'paths' => [], //'%appDir%'
+		'excludePaths' => [],
 		'ignore' => [],
 		'cache' => FilesystemCache::class,
 		'cacheDir' => '%tempDir%/cache/Doctrine.Annotations',
@@ -67,7 +68,8 @@ class OrmAnnotationsExtension extends CompilerExtension
 			]);
 
 		$builder->addDefinition($this->prefix('annotationDriver'))
-			->setClass(AnnotationDriver::class, [$this->prefix('@reader'), Helpers::expand($config['paths'], $builder->parameters)]);
+			->setClass(AnnotationDriver::class, [$this->prefix('@reader'), Helpers::expand($config['paths'], $builder->parameters)])
+			->addSetup('addExcludePaths', [Helpers::expand($config['excludePaths'], $builder->parameters)]);
 
 		$builder->getDefinitionByType(Configuration::class)
 			->addSetup('setMetadataDriverImpl', [$this->prefix('@annotationDriver')]);


### PR DESCRIPTION
Adds configuration option for excluding some paths from annotation driver search.

This is useful when you have some executable code in searched directories.

For example when you have whole `%appDir%` in paths, you can exclude `%appDir%/bootstrap.php` and other files, so their code is not executed when the annotation driver parses annotations. Otherwise it would be, as the parsed files are included inside `AnnotationDriver::getAllClassNames` method by `require_once` function.