### PR TITLE
OrmAnnotationsExtension: enhance cache driver configuration

### DIFF
--- a/src/DI/OrmAnnotationsExtension.php
+++ b/src/DI/OrmAnnotationsExtension.php
@@ -54,8 +54,13 @@ class OrmAnnotationsExtension extends CompilerExtension
 		}
 
 		// Cache
-		$builder->addDefinition($this->prefix('annotationsCache'))
-			->setFactory($config['cache'], [Helpers::expand($config['cacheDir'], $builder->parameters)]);
+		$cache = $builder->addDefinition($this->prefix('annotationsCache'))
+			->setFactory($config['cache'])
+			->setAutowired(false);
+
+		if ($config['cache'] === FilesystemCache::class) {
+			$cache->setArguments([Helpers::expand($config['cacheDir'], $builder->parameters)]);
+		}
 
 		//TODO otestovat predani @...
 


### PR DESCRIPTION
This PR:

- disables autowiring of annotations cache driver (related to #23);
- configures the driver with cache directory path only if it is configured to use FilesystemCache.