### PR TITLE
Missing function call

### DIFF
--- a/src/DI/OrmCacheExtension.php
+++ b/src/DI/OrmCacheExtension.php
@@ -54,6 +54,7 @@ class OrmCacheExtension extends CompilerExtension
 		$this->loadHydrationCacheConfiguration();
 		$this->loadResultCacheConfiguration();
 		$this->loadMetadataCacheConfiguration();
+		$this->loadSecondLevelCacheConfiguration();
 	}
 
 	public function loadQueryCacheConfiguration(): void


### PR DESCRIPTION
Missing function call for enabling SecondLevelCache.

$this->loadSecondLevelCacheConfiguration();