### PR TITLE
Support for XML mapping

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -164,6 +164,22 @@ orm.annotations:
     cache: @cacheReader
 ```
 
+### XML Bridge
+
+Are you using XML mapping for your entities?
+
+You will need the `OrmXmlExtension`. This is the default configuration:
+
+```yaml
+extensions:
+    orm: Nettrine\ORM\DI\OrmExtension
+    orm.xml: Nettrine\ORM\DI\OrmXmlExtension
+
+orm.xml:
+    paths: []
+    fileExtension: .dcm.xml
+```
+
 ### Cache Bridge
 
 This extension sets up cache for all important parts: `queryCache`, `resultCache`, `hydrationCache`, `metadataCache` and `secondLevelCache`.

--- a/src/DI/OrmXmlExtension.php
+++ b/src/DI/OrmXmlExtension.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace Nettrine\ORM\DI;
+
+use Nette\DI\CompilerExtension;
+
+final class OrmXmlExtension extends CompilerExtension
+{
+
+}

--- a/src/DI/OrmXmlExtension.php
+++ b/src/DI/OrmXmlExtension.php
@@ -34,7 +34,7 @@ class OrmXmlExtension extends CompilerExtension
 		$builder->addDefinition($this->prefix('xmlDriver'))
 			->setFactory(XmlDriver::class, [
 				Helpers::expand($config['paths'], $builder->parameters),
-				$config['fileExtension']
+				$config['fileExtension'],
 			]);
 
 		$builder->getDefinitionByType(Configuration::class)

--- a/src/DI/OrmXmlExtension.php
+++ b/src/DI/OrmXmlExtension.php
@@ -2,9 +2,61 @@
 
 namespace Nettrine\ORM\DI;
 
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Annotations\CachedReader;
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\Cache\ApcCache;
+use Doctrine\Common\Cache\ApcuCache;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\FilesystemCache;
+use Doctrine\Common\Cache\MemcacheCache;
+use Doctrine\Common\Cache\MemcachedCache;
+use Doctrine\Common\Cache\RedisCache;
+use Doctrine\Common\Cache\VoidCache;
+use Doctrine\Common\Cache\XcacheCache;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Nette\DI\CompilerExtension;
+use Nette\DI\Helpers;
+use Nette\DI\ServiceDefinition;
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\PhpLiteral;
+use Nette\Utils\Validators;
+use Nettrine\ORM\Exception\Logical\InvalidStateException;
+use Nettrine\ORM\Mapping\AnnotationDriver;
 
-final class OrmXmlExtension extends CompilerExtension
+class OrmXmlExtension extends CompilerExtension
 {
+
+	/** @var mixed[] */
+	public $defaults = [
+		'paths' => [], //'%appDir%'
+		'fileExtension' => XmlDriver::DEFAULT_FILE_EXTENSION,
+	];
+
+	/**
+	 * Register services
+	 */
+	public function loadConfiguration(): void
+	{
+		if (!$this->compiler->getExtensions(OrmExtension::class)) {
+			throw new InvalidStateException(
+				sprintf('You should register %s before %s.', self::class, static::class)
+			);
+		}
+
+		$builder = $this->getContainerBuilder();
+		$config = $this->validateConfig($this->defaults);
+
+		$builder->addDefinition($this->prefix('xmlDriver'))
+			->setFactory(XmlDriver::class, [
+				Helpers::expand($config['paths'], $builder->parameters),
+				$config['fileExtension']
+			]);
+
+		$builder->getDefinitionByType(Configuration::class)
+			->addSetup('setMetadataDriverImpl', [$this->prefix('@xmlDriver')]);
+	}
 
 }

--- a/src/DI/OrmXmlExtension.php
+++ b/src/DI/OrmXmlExtension.php
@@ -2,29 +2,11 @@
 
 namespace Nettrine\ORM\DI;
 
-use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
-use Doctrine\Common\Annotations\CachedReader;
-use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Cache\ApcCache;
-use Doctrine\Common\Cache\ApcuCache;
-use Doctrine\Common\Cache\ArrayCache;
-use Doctrine\Common\Cache\FilesystemCache;
-use Doctrine\Common\Cache\MemcacheCache;
-use Doctrine\Common\Cache\MemcachedCache;
-use Doctrine\Common\Cache\RedisCache;
-use Doctrine\Common\Cache\VoidCache;
-use Doctrine\Common\Cache\XcacheCache;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Nette\DI\CompilerExtension;
 use Nette\DI\Helpers;
-use Nette\DI\ServiceDefinition;
-use Nette\PhpGenerator\ClassType;
-use Nette\PhpGenerator\PhpLiteral;
-use Nette\Utils\Validators;
 use Nettrine\ORM\Exception\Logical\InvalidStateException;
-use Nettrine\ORM\Mapping\AnnotationDriver;
 
 class OrmXmlExtension extends CompilerExtension
 {

--- a/tests/cases/DI/OrmXmlExtensionTest.php
+++ b/tests/cases/DI/OrmXmlExtensionTest.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Nettrine\ORM\Cases\DI;
+
+use Tests\Nettrine\ORM\Cases\TestCase;
+
+final class OrmXmlExtensionTest extends TestCase
+{
+
+}

--- a/tests/cases/DI/OrmXmlExtensionTest.php
+++ b/tests/cases/DI/OrmXmlExtensionTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Nettrine\ORM\Cases\DI;
 
-use Doctrine\Common\Cache\FilesystemCache;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Nette\DI\Compiler;
 use Nette\DI\Container;

--- a/tests/cases/DI/OrmXmlExtensionTest.php
+++ b/tests/cases/DI/OrmXmlExtensionTest.php
@@ -2,9 +2,38 @@
 
 namespace Tests\Nettrine\ORM\Cases\DI;
 
+use Doctrine\Common\Cache\FilesystemCache;
+use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Nette\DI\Compiler;
+use Nette\DI\Container;
+use Nette\DI\ContainerLoader;
+use Nettrine\DBAL\DI\DbalExtension;
+use Nettrine\ORM\DI\OrmExtension;
+use Nettrine\ORM\DI\OrmXmlExtension;
 use Tests\Nettrine\ORM\Cases\TestCase;
 
 final class OrmXmlExtensionTest extends TestCase
 {
+
+	public function testExtensionCanBeRegistered(): void
+	{
+		$loader = new ContainerLoader(TEMP_PATH, true);
+		$class = $loader->load(function (Compiler $compiler): void {
+			$compiler->addExtension('dbal', new DbalExtension());
+			$compiler->addExtension('orm', new OrmExtension());
+			$compiler->addExtension('orm.xml', new OrmXmlExtension());
+			$compiler->addConfig([
+				'parameters' => [
+					'tempDir' => TEMP_PATH,
+					'appDir' => __DIR__,
+				],
+			]);
+		}, self::class . __METHOD__);
+
+		/** @var Container $container */
+		$container = new $class();
+
+		self::assertInstanceOf(XmlDriver::class, $container->getService('orm.xml.xmlDriver'));
+	}
 
 }


### PR DESCRIPTION
Closes #6 

@f3l1x code review is appreciated. I have noticed that there is cache for annotation driver (the cache reader), but nothing like that for xml mapping - maybe it is necessary, though i could miss something.

This implementation seems to be so lightweight, maybe it is enough and does not need to be more complicated 😄 