### PR TITLE
Refactoring to support Nette v3

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -1,46 +1,32 @@
-# Nettrine / ORM
+# Nettrine ORM
+
+Integration of [Doctrine\ORM](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/) to Nette Framework.
 
 ## Content
 
-- [Minimal configuration](#minimal-configuration)
+- [Setup](#setup)
 - [ORM extension](#ormextension)
 	- [EntityManagerDecorator](#entitymanagerdecorator)
 	- [Configuration](#configuration)
 - [Bridges](#bridges)
 	- [Annotations Bridge](#annotations-bridge)
+	- [XML Bridge](#xml-bridge)
 	- [Cache Bridge](#cache-bridge)
 	- [Console Bridge](#console-bridge)
 - [Other features](#other-features)
 	- [ID attribute](#id-attribute)
 
-## Minimal configuration
+## Setup
 
-At first, you will need the Doctrine DBAL extension. Take a look at [Nettrine DBAL](https://github.com/nettrine/dbal) in this organization. Install `nettrine/dbal` package using composer.
+First of all, install [Nettrine DBAL](https://github.com/nettrine/dbal) package and enable `DbalExtension`.
 
-```
-composer require nettrine/dbal
-```
+Install package
 
-Place `DbalExtension` in your neon config file.
-
-```yaml
-extensions:
-    dbal: Nettrine\DBAL\DI\DbalExtension
+```bash
+composer require nettrine/orm
 ```
 
-And set-up DBAL connection.
-
-```yaml
-dbal:
-    connection:
-        host: 127.0.0.1
-        user: root
-        password:
-        dbname: nettrine
-        #driver: pdo_pgsql
-```
-
-Secondly, enable the Doctrine ORM extension. It's provided by this package.
+Register extension
 
 ```yaml
 extensions:

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@ tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore
+Makefile export-ignore
 phpstan.neon export-ignore
 README.md export-ignore
 ruleset.xml export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,52 @@
 language: php
-
 php:
   - 7.2
   - 7.3
   - 7.4snapshot
+  - nightly
 
 before_install:
-  # Turn off XDebug
-  - phpenv config-rm xdebug.ini || return 0
+  - phpenv config-rm xdebug.ini || return 0 # Turn off XDebug
 
 install:
-  # Composer
-  - travis_retry composer install --no-progress --prefer-dist
+  - travis_retry composer install --no-progress --prefer-dist # Install dependencies
 
 script:
-  # Tests
-  - composer run-script tests
+  - make tests # Tests
 
 jobs:
   include:
-    - env: title="Lowest Dependencies 7.2"
-      php: 7.2
+    - env: title="Lowest Dependencies 7.3"
+      php: 7.3
       install:
-        - travis_retry composer update --no-progress --prefer-dist --prefer-lowest
+        - travis_retry composer update --no-progress --prefer-dist --prefer-lowest --prefer-stable
       script:
-        - composer run-script tests
+        - make tests
 
     - stage: Quality Assurance
-      php: 7.2
+      php: 7.3
       script:
-        - composer run-script qa
-
-    - stage: Phpstan
-      php: 7.2
-      script:
-        - composer run-script phpstan
+        - make qa
 
     - stage: Test Coverage
       if: branch = master AND type = push
-      php: 7.2
+      php: 7.3
       script:
-        - composer run-script coverage
+        - make coverage
       after_script:
         - composer global require php-coveralls/php-coveralls ^2.1.0
         - ~/.composer/vendor/bin/php-coveralls --verbose --config tests/.coveralls.yml
 
     - stage: Outdated Dependencies
       if: branch = master AND type = cron
-      php: 7.2
+      php: 7.3
       script:
-        - composer outdated --direct --strict
+        - composer outdated --direct
 
   allow_failures:
-    - php: 7.4snapshot
     - stage: Test Coverage
+    - php: 7.4snapshot
+    - php: nightly
 
 sudo: false
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: qa lint cs csf phpstan tests coverage
+
+all:
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | xargs
+
+vendor: composer.json composer.lock
+	composer install
+
+qa: lint phpstan cs
+
+lint: vendor
+	vendor/bin/linter src tests
+
+cs: vendor
+	vendor/bin/codesniffer src tests
+
+csf: vendor
+	vendor/bin/codefixer src tests
+
+phpstan: vendor
+	vendor/bin/phpstan analyse -l max -c phpstan.neon src
+
+tests: vendor
+	vendor/bin/phpunit tests --cache-result-file=tests/tmp/phpunit.cache --colors=always
+
+coverage: vendor
+	vendor/bin/phpdbg -qrr vendor/bin/phpunit tests --cache-result-file=tests/tmp/phpunit.cache --colors=always -c tests/coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Doctrine ORM
+# Nettrine ORM
 
 Integration of [Doctrine\ORM](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/) to Nette Framework.
-
------
 
 [![Build Status](https://img.shields.io/travis/nettrine/orm.svg?style=flat-square)](https://travis-ci.org/nettrine/orm)
 [![Code coverage](https://img.shields.io/coveralls/nettrine/orm.svg?style=flat-square)](https://coveralls.io/r/nettrine/orm)
@@ -16,31 +14,26 @@ Integration of [Doctrine\ORM](http://docs.doctrine-project.org/projects/doctrine
 
 [![Join the chat](https://img.shields.io/gitter/room/nettrine/nettrine.svg?style=flat-square)](https://gitter.im/nettrine/nettrine)
 
-## Install
+## Documentation
 
-```sh
-composer require nettrine/orm
-```
+- [Setup](.docs/README.md#setup)
+- [ORM extension](.docs/README.md#ormextension)
+	- [EntityManagerDecorator](.docs/README.md#entitymanagerdecorator)
+	- [Configuration](.docs/README.md#configuration)
+- [Bridges](.docs/README.md#bridges)
+	- [Annotations Bridge](.docs/README.md#annotations-bridge)
+	- [XML Bridge](.docs/README.md#xml-bridge)
+	- [Cache Bridge](.docs/README.md#cache-bridge)
+	- [Console Bridge](.docs/README.md#console-bridge)
+- [Other features](.docs/README.md#other-features)
+	- [ID attribute](.docs/README.md#id-attribute)
+
 ## Versions
 
-| State       | Version       | Branch   | PHP      |
-|-------------|---------------|----------|----------|
-| development | `^0.4`        | `master` | `>= 7.1` |
-| stable      | `^0.3`        | `master` | `>= 7.1` |
-
-## Overview
-
-- [Minimal configuration](https://github.com/nettrine/orm/blob/master/.docs/README.md#minimal-configuration)
-- [ORM extension](https://github.com/nettrine/orm/blob/master/.docs/README.md#ormextension)
-	- [Own entity manager](https://github.com/nettrine/orm/blob/master/.docs/README.md#own-entitymanager)
-	- [Configuration](https://github.com/nettrine/orm/blob/master/.docs/README.md#configuration)
-- [Bridges](https://github.com/nettrine/orm/blob/master/.docs/README.md#bridges)
-	- [Annotations Bridge](https://github.com/nettrine/orm/blob/master/.docs/README.md#annotations-bridge)
-	- [XML Bridge](https://github.com/nettrine/orm/blob/master/.docs/README.md#xml-bridge)
-	- [Cache Bridge](https://github.com/nettrine/orm/blob/master/.docs/README.md#cache-bridge)
-	- [Console Bridge](https://github.com/nettrine/orm/blob/master/.docs/README.md#console-bridge)
-- [Other features](https://github.com/nettrine/orm/blob/master/.docs/README.md#other-features)
-	- [ID attribute](https://github.com/nettrine/orm/blob/master/.docs/README.md#id-attribute)
+| State       | Version     | Branch   | Nette  | PHP    |
+|-------------|-------------|----------|--------|--------|
+| development | `^0.5`      | `master` | `3.0+` | `^7.2` |
+| stable      | `^0.4`      | `master` | `2.4`  | `^7.1` |
 
 ## Other
 
@@ -72,7 +65,5 @@ This repository is inspired by these packages:
     </tr>
   </tbody>
 </table>
-
------
 
 Thank you for testing, reporting and contributing.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "nettrine/orm",
-  "description": "Well-integrated Doctrine2 ORM for Nette Framework",
+  "description": "Doctrine ORM for Nette Framework",
   "keywords": ["nette", "doctrine", "orm", "database"],
   "type": "library",
   "license": "MIT",
@@ -16,23 +16,24 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
-    "nette/di": "~2.4.14 || ~3.0.0",
-    "nette/utils": "~2.5.3 || ~3.0.0",
-    "symfony/console": "^4.2.3",
-    "nettrine/dbal": "^0.2.0 || ^0.3.0",
+    "php": "^7.2",
+    "nette/di": "~3.0.0",
+    "nette/utils": "~3.0.1",
+    "symfony/console": "^4.2.5",
+    "nettrine/dbal": "^0.4.0 || ^0.5.0",
     "doctrine/orm": "^2.6.3",
     "doctrine/cache": "^1.8.0",
-    "doctrine/annotations": "^1.6.0"
+    "doctrine/annotations": "^1.6.1"
   },
   "require-dev": {
-    "ninjify/qa": "^0.9.0",
     "mockery/mockery": "^1.2.2",
-    "phpunit/phpunit": "^8.0.4",
-    "phpstan/phpstan-shim": "^0.11.2",
+    "ninjify/qa": "^0.9.0",
+    "phpstan/extension-installer": "^1.0",
     "phpstan/phpstan-deprecation-rules": "^0.11.0",
-    "phpstan/phpstan-nette": "^0.11.1",
-    "phpstan/phpstan-strict-rules": "^0.11.0"
+    "phpstan/phpstan-nette": "^0.11.0",
+    "phpstan/phpstan-shim": "^0.11.5",
+    "phpstan/phpstan-strict-rules": "^0.11.0",
+    "phpunit/phpunit": "^8.1.0"
   },
   "autoload": {
     "psr-4": {
@@ -41,30 +42,19 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Tests\\Nettrine\\ORM\\Cases\\": "tests/cases",
-      "Tests\\Nettrine\\ORM\\Fixtures\\": "tests/fixtures"
+      "Tests\\Cases\\": "tests/cases",
+      "Tests\\Fixtures\\": "tests/fixtures",
+      "Tests\\Toolkit\\": "tests/toolkit"
     }
   },
   "minimum-stability": "dev",
   "prefer-stable": true,
-  "scripts": {
-    "qa": [
-      "linter src tests",
-      "codesniffer src tests"
-    ],
-    "tests": [
-      "phpunit tests --cache-result-file=tests/tmp/phpunit.cache --colors=always"
-    ],
-    "coverage": [
-      "phpdbg -qrr vendor/bin/phpunit tests --cache-result-file=tests/tmp/phpunit.cache --colors=always -c tests/coverage.xml"
-    ],
-    "phpstan": [
-      "vendor/bin/phpstan analyse -l max -c phpstan.neon src"
-    ]
+  "config": {
+    "sort-packages": true
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "0.4.x-dev"
+      "dev-next": "0.5.x-dev"
     }
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,12 +1,8 @@
-includes:
-	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
-	- vendor/phpstan/phpstan-nette/extension.neon
-	- vendor/phpstan/phpstan-nette/rules.neon
-	- vendor/phpstan/phpstan-strict-rules/rules.neon
-
 parameters:
 	ignoreErrors:
-		# Will be removed same time as from Doctrine
-		- '#^Fetching class constant class of deprecated class Doctrine\\Common\\Cache\\(ApcCache|MemcacheCache|XcacheCache)\.$#'
+		# PHPStan bug, there is no Doctrine\Orm\Configuration assignment
+		- '#^Parameter \#1 \$type of method Nette\\DI\\Definitions\\ServiceDefinition::setType\(\) expects string|null, Doctrine\\ORM\\Configuration|string given$#'
 		# No replacement available yet
-		- '#^Call to deprecated method registerUniqueLoader\(\) of class Doctrine\\Common\\Annotations\\AnnotationRegistry\.$#'
+		- '#^Call to deprecated method registerUniqueLoader\(\) of class Doctrine\\Common\\Annotations\\AnnotationRegistry.+#'
+		# We will replace it once, for sure
+		- '#Fetching class constant .+ of deprecated class Doctrine\\Common\\Proxy\\AbstractProxyFactory.+#'

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0"?>
-<ruleset name="Nettrine">
+<ruleset>
 	<!-- Contributte Coding Standard -->
 	<rule ref="./vendor/ninjify/coding-standard/contributte.xml">
 		<exclude name="SlevomatCodingStandard.ControlStructures.RequireTernaryOperator.TernaryOperatorNotUsed"/>
+		<exclude name="SlevomatCodingStandard.ControlStructures.ControlStructureSpacing.IncorrectLinesCountBeforeControlStructure"/>
+		<exclude name="SlevomatCodingStandard.ControlStructures.ControlStructureSpacing.IncorrectLinesCountAfterControlStructure"/>
+		<exclude name="SlevomatCodingStandard.ControlStructures.ControlStructureSpacing.IncorrectLinesCountAfterLastControlStructure"/>
+		<exclude name="SlevomatCodingStandard.ControlStructures.RequireMultiLineTernaryOperator.MultiLineTernaryOperatorNotUsed"/>
 	</rule>
 
 	<!-- Specific -->
@@ -10,8 +14,9 @@
 		<properties>
 			<property name="rootNamespaces" type="array" value="
 				src=>Nettrine\ORM,
-				tests/cases=>Tests\Nettrine\ORM\Cases,
-				tests/fixtures=>Tests\Nettrine\ORM\Fixtures
+				tests/cases=>Tests\Cases,
+				tests/fixtures=>Tests\Fixtures,
+				tests/toolkit=>Tests\Toolkit
 			"/>
 		</properties>
 	</rule>

--- a/src/DI/AbstractExtension.php
+++ b/src/DI/AbstractExtension.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace Nettrine\ORM\DI;
+
+use Doctrine\ORM\Configuration;
+use Nette\DI\CompilerExtension;
+use Nette\DI\Definitions\ServiceDefinition;
+use Nettrine\ORM\Exception\Logical\InvalidStateException;
+use stdClass;
+
+/**
+ * @property-read stdClass $config
+ */
+abstract class AbstractExtension extends CompilerExtension
+{
+
+	public function validate(): void
+	{
+		if ($this->compiler->getExtensions(OrmExtension::class) === []) {
+			throw new InvalidStateException(
+				sprintf('You should register %s before %s.', OrmExtension::class, static::class)
+			);
+		}
+	}
+
+	protected function getConfigurationDef(): ServiceDefinition
+	{
+		/** @var ServiceDefinition $def */
+		$def = $this->getContainerBuilder()->getDefinitionByType(Configuration::class);
+
+		return $def;
+	}
+
+}

--- a/src/DI/Helpers/CacheBuilder.php
+++ b/src/DI/Helpers/CacheBuilder.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types = 1);
+
+namespace Nettrine\ORM\DI\Helpers;
+
+use Doctrine\Common\Cache\ApcuCache;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\FilesystemCache;
+use Doctrine\Common\Cache\MemcachedCache;
+use Doctrine\Common\Cache\RedisCache;
+use Doctrine\Common\Cache\VoidCache;
+use Nette\DI\CompilerExtension;
+use Nette\DI\Definitions\ServiceDefinition;
+use Nettrine\ORM\Exception\Logical\InvalidStateException;
+
+/**
+ * @mixin CompilerExtension
+ */
+class CacheBuilder
+{
+
+	private const DRIVERS = [
+		'apcu' => ApcuCache::class,
+		'array' => ArrayCache::class,
+		'filesystem' => FilesystemCache::class,
+		'memcached' => MemcachedCache::class,
+		'redis' => RedisCache::class,
+		'void' => VoidCache::class,
+	];
+
+	/** @var CompilerExtension */
+	private $extension;
+
+	/** @var string */
+	private $default = 'filesystem';
+
+	private function __construct(CompilerExtension $extension)
+	{
+		$this->extension = $extension;
+	}
+
+	public static function of(CompilerExtension $extension): self
+	{
+		return new self($extension);
+	}
+
+	public function withDefault(string $driver): self
+	{
+		if (!isset(self::DRIVERS[$driver])) {
+			throw new InvalidStateException(sprintf('Unsupported default cache driver "%s"', $driver));
+		}
+
+		$this->default = $driver;
+
+		return $this;
+	}
+
+	public function getDefinition(string $service): ServiceDefinition
+	{
+		$builder = $this->extension->getContainerBuilder();
+
+		$def = $builder->addDefinition($this->extension->prefix($service))
+			->setFactory(self::DRIVERS[$this->default])
+			->setAutowired(false);
+
+		if ($this->default === 'filesystem') {
+			$def->setArguments([$builder->parameters['tempDir'] . '/cache/nettrine.cache.' . ucfirst($service)]);
+		}
+
+		return $def;
+	}
+
+}

--- a/src/DI/OrmAnnotationsExtension.php
+++ b/src/DI/OrmAnnotationsExtension.php
@@ -6,81 +6,60 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Cache\ApcCache;
-use Doctrine\Common\Cache\ApcuCache;
-use Doctrine\Common\Cache\ArrayCache;
-use Doctrine\Common\Cache\FilesystemCache;
-use Doctrine\Common\Cache\MemcacheCache;
-use Doctrine\Common\Cache\MemcachedCache;
-use Doctrine\Common\Cache\RedisCache;
-use Doctrine\Common\Cache\VoidCache;
-use Doctrine\Common\Cache\XcacheCache;
-use Doctrine\ORM\Configuration;
-use Nette\DI\CompilerExtension;
-use Nette\DI\Helpers;
-use Nette\DI\ServiceDefinition;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\PhpLiteral;
-use Nette\Utils\Validators;
+use Nette\Schema\Expect;
+use Nette\Schema\Schema;
+use Nettrine\ORM\DI\Helpers\CacheBuilder;
 use Nettrine\ORM\Exception\Logical\InvalidStateException;
 use Nettrine\ORM\Mapping\AnnotationDriver;
+use stdClass;
 
-class OrmAnnotationsExtension extends CompilerExtension
+/**
+ * @property-read stdClass $config
+ */
+class OrmAnnotationsExtension extends AbstractExtension
 {
 
-	public const DRIVERS = [
-		'apc' => ApcCache::class,
-		'apcu' => ApcuCache::class,
-		'array' => ArrayCache::class,
-		'filesystem' => FilesystemCache::class,
-		'memcache' => MemcacheCache::class,
-		'memcached' => MemcachedCache::class,
-		'redis' => RedisCache::class,
-		'void' => VoidCache::class,
-		'xcache' => XcacheCache::class,
-	];
-
-	/** @var mixed[] */
-	public $defaults = [
-		'paths' => [], //'%appDir%'
-		'excludePaths' => [],
-		'ignore' => [],
-		'defaultCache' => 'filesystem',
-		'cache' => null,
-		'debug' => false,
-	];
+	public function getConfigSchema(): Schema
+	{
+		return Expect::structure([
+			'debug' => Expect::bool(false),
+			'cache' => Expect::string()->nullable(),
+			'defaultCache' => Expect::string('filesystem')->nullable(),
+			'paths' => Expect::listOf('string'),
+			'excludePaths' => Expect::listOf('string'),
+			'ignore' => Expect::listOf('string'),
+		]);
+	}
 
 	/**
 	 * Register services
 	 */
 	public function loadConfiguration(): void
 	{
-		if ($this->compiler->getExtensions(OrmExtension::class) === []) {
-			throw new InvalidStateException(
-				sprintf('You should register %s before %s.', self::class, static::class)
-			);
-		}
+		// Validates needed extension
+		$this->validate();
 
 		$builder = $this->getContainerBuilder();
-		$config = $this->validateConfig($this->defaults);
+		$config = $this->config;
 
 		$reader = $builder->addDefinition($this->prefix('annotationReader'))
 			->setType(AnnotationReader::class)
 			->setAutowired(false);
 
-		Validators::assertField($config, 'ignore', 'array');
-
-		foreach ($config['ignore'] as $annotationName) {
+		foreach ($config->ignore as $annotationName) {
 			$reader->addSetup('addGlobalIgnoredName', [$annotationName]);
 			AnnotationReader::addGlobalIgnoredName($annotationName);
 		}
 
-		if ($config['cache'] === null && $config['defaultCache'] !== null) {
-			$this->getDefaultCache()
-				->setAutowired(false);
-		} elseif ($config['cache'] !== null) {
+		if ($config->cache === null && $config->defaultCache !== null) {
+			CacheBuilder::of($this)
+				->withDefault($config->defaultCache)
+				->getDefinition('annotationsCache');
+		} elseif ($config->cache !== null) {
 			$builder->addDefinition($this->prefix('annotationsCache'))
-				->setFactory($config['cache'])
+				->setFactory($config->cache)
 				->setAutowired(false);
 		} else {
 			throw new InvalidStateException('Cache or defaultCache must be provided');
@@ -91,16 +70,17 @@ class OrmAnnotationsExtension extends CompilerExtension
 			->setFactory(CachedReader::class, [
 				$this->prefix('@annotationReader'),
 				$this->prefix('@annotationsCache'),
-				$config['debug'],
+				$config->debug,
 			]);
 
 		$builder->addDefinition($this->prefix('annotationDriver'))
-			->setFactory(AnnotationDriver::class, [$this->prefix('@reader'), Helpers::expand($config['paths'], $builder->parameters)])
-			->addSetup('addExcludePaths', [Helpers::expand($config['excludePaths'], $builder->parameters)]);
+			->setFactory(AnnotationDriver::class, [$this->prefix('@reader'), $config->paths])
+			->addSetup('addExcludePaths', [$config->excludePaths]);
 
-		$builder->getDefinitionByType(Configuration::class)
-			->addSetup('setMetadataDriverImpl', [$this->prefix('@annotationDriver')]);
+		$configurationDef = $this->getConfigurationDef();
+		$configurationDef->addSetup('setMetadataDriverImpl', [$this->prefix('@annotationDriver')]);
 
+		// Just for runtime
 		AnnotationRegistry::registerUniqueLoader('class_exists');
 	}
 
@@ -110,26 +90,6 @@ class OrmAnnotationsExtension extends CompilerExtension
 		$original = (string) $initialize->getBody();
 		$initialize->setBody('?::registerUniqueLoader("class_exists");' . "\n", [new PhpLiteral(AnnotationRegistry::class)]);
 		$initialize->addBody($original);
-	}
-
-	protected function getDefaultCache(): ServiceDefinition
-	{
-		$config = $this->getConfig();
-		$builder = $this->getContainerBuilder();
-
-		if (!isset(self::DRIVERS[$config['defaultCache']])) {
-			throw new InvalidStateException(sprintf('Unsupported default cache driver "%s"', $config['defaultCache']));
-		}
-
-		$driverCache = $builder->addDefinition($this->prefix('annotationsCache'))
-			->setFactory(self::DRIVERS[$config['defaultCache']])
-			->setAutowired(false);
-
-		if ($config['defaultCache'] === 'filesystem') {
-			$driverCache->setArguments([$builder->parameters['tempDir'] . '/cache/Doctrine.Annotations']);
-		}
-
-		return $driverCache;
 	}
 
 }

--- a/src/DI/Traits/TEntityMapping.php
+++ b/src/DI/Traits/TEntityMapping.php
@@ -1,10 +1,14 @@
 <?php declare(strict_types = 1);
 
-namespace Nettrine\ORM\DI;
+namespace Nettrine\ORM\DI\Traits;
 
 use Doctrine\Common\Persistence\Mapping\Driver\AnnotationDriver;
-use Nette\DI\ContainerBuilder;
+use Nette\DI\CompilerExtension;
+use Nette\DI\Definitions\ServiceDefinition;
 
+/**
+ * @mixin CompilerExtension
+ */
 trait TEntityMapping
 {
 
@@ -13,9 +17,9 @@ trait TEntityMapping
 	 */
 	public function setEntityMappings(array $mapping): void
 	{
-		/** @var ContainerBuilder $builder */
 		$builder = $this->getContainerBuilder();
 
+		/** @var ServiceDefinition $driver */
 		$driver = $builder->getDefinitionByType(AnnotationDriver::class);
 		$driver->addSetup('addPaths', [$mapping]);
 	}

--- a/tests/cases/Unit/DI/OrmAnnotationsExtensionTest.php
+++ b/tests/cases/Unit/DI/OrmAnnotationsExtensionTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Tests\Nettrine\ORM\Cases\DI;
+namespace Tests\Cases\Unit\DI;
 
 use Doctrine\Common\Cache\FilesystemCache;
 use Nette\DI\Compiler;
@@ -10,7 +10,7 @@ use Nettrine\DBAL\DI\DbalExtension;
 use Nettrine\ORM\DI\OrmAnnotationsExtension;
 use Nettrine\ORM\DI\OrmExtension;
 use Nettrine\ORM\Exception\Logical\InvalidStateException;
-use Tests\Nettrine\ORM\Cases\TestCase;
+use Tests\Toolkit\TestCase;
 
 final class OrmAnnotationsExtensionTest extends TestCase
 {
@@ -33,7 +33,7 @@ final class OrmAnnotationsExtensionTest extends TestCase
 		/** @var Container $container */
 		$container = new $class();
 
-		self::assertInstanceOf(FilesystemCache::class, $container->getService('orm.annotations.annotationsCache'));
+		$this->assertInstanceOf(FilesystemCache::class, $container->getService('orm.annotations.annotationsCache'));
 	}
 
 	public function testNoCache(): void

--- a/tests/cases/Unit/DI/OrmCacheExtensionTest.php
+++ b/tests/cases/Unit/DI/OrmCacheExtensionTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Tests\Nettrine\ORM\Cases\DI;
+namespace Tests\Cases\Unit\DI;
 
 use Doctrine\Common\Cache\FilesystemCache;
 use Nette\DI\Compiler;
@@ -11,7 +11,7 @@ use Nettrine\ORM\DI\OrmAnnotationsExtension;
 use Nettrine\ORM\DI\OrmCacheExtension;
 use Nettrine\ORM\DI\OrmExtension;
 use Nettrine\ORM\EntityManagerDecorator;
-use Tests\Nettrine\ORM\Cases\TestCase;
+use Tests\Toolkit\TestCase;
 
 final class OrmCacheExtensionTest extends TestCase
 {
@@ -34,13 +34,14 @@ final class OrmCacheExtensionTest extends TestCase
 
 		/** @var Container $container */
 		$container = new $class();
+
 		/** @var EntityManagerDecorator $em */
 		$em = $container->getByType(EntityManagerDecorator::class);
 
-		self::assertInstanceOf(FilesystemCache::class, $em->getConfiguration()->getHydrationCacheImpl());
-		self::assertInstanceOf(FilesystemCache::class, $em->getConfiguration()->getMetadataCacheImpl());
-		self::assertInstanceOf(FilesystemCache::class, $em->getConfiguration()->getQueryCacheImpl());
-		self::assertInstanceOf(FilesystemCache::class, $em->getConfiguration()->getResultCacheImpl());
+		$this->assertInstanceOf(FilesystemCache::class, $em->getConfiguration()->getHydrationCacheImpl());
+		$this->assertInstanceOf(FilesystemCache::class, $em->getConfiguration()->getMetadataCacheImpl());
+		$this->assertInstanceOf(FilesystemCache::class, $em->getConfiguration()->getQueryCacheImpl());
+		$this->assertInstanceOf(FilesystemCache::class, $em->getConfiguration()->getResultCacheImpl());
 	}
 
 }

--- a/tests/cases/Unit/DI/OrmExtensionTest.php
+++ b/tests/cases/Unit/DI/OrmExtensionTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Tests\Nettrine\ORM\Cases\DI;
+namespace Tests\Cases\Unit\DI;
 
 use Nette\DI\Compiler;
 use Nette\DI\Container;
@@ -11,9 +11,9 @@ use Nettrine\ORM\DI\OrmAnnotationsExtension;
 use Nettrine\ORM\DI\OrmExtension;
 use Nettrine\ORM\EntityManagerDecorator;
 use stdClass;
-use Tests\Nettrine\ORM\Cases\TestCase;
-use Tests\Nettrine\ORM\Fixtures\DummyConfiguration;
-use Tests\Nettrine\ORM\Fixtures\DummyEntityManagerDecorator;
+use Tests\Fixtures\DummyConfiguration;
+use Tests\Fixtures\DummyEntityManagerDecorator;
+use Tests\Toolkit\TestCase;
 
 final class OrmExtensionTest extends TestCase
 {
@@ -35,7 +35,7 @@ final class OrmExtensionTest extends TestCase
 
 		/** @var Container $container */
 		$container = new $class();
-		self::assertInstanceOf(EntityManagerDecorator::class, $container->getByType(EntityManagerDecorator::class));
+		$this->assertInstanceOf(EntityManagerDecorator::class, $container->getByType(EntityManagerDecorator::class));
 	}
 
 	public function testOwnEntityManager(): void
@@ -61,8 +61,8 @@ final class OrmExtensionTest extends TestCase
 
 		/** @var Container $container */
 		$container = new $class();
-		self::assertInstanceOf(DummyEntityManagerDecorator::class, $container->getByType(DummyEntityManagerDecorator::class));
-		self::assertInstanceOf(DummyConfiguration::class, $container->getByType(DummyConfiguration::class));
+		$this->assertInstanceOf(DummyEntityManagerDecorator::class, $container->getByType(DummyEntityManagerDecorator::class));
+		$this->assertInstanceOf(DummyConfiguration::class, $container->getByType(DummyConfiguration::class));
 	}
 
 	public function testConfigurationException(): void

--- a/tests/cases/Unit/DI/OrmXmlExtensionTest.php
+++ b/tests/cases/Unit/DI/OrmXmlExtensionTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Tests\Nettrine\ORM\Cases\DI;
+namespace Tests\Cases\Unit\DI;
 
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Nette\DI\Compiler;
@@ -9,12 +9,12 @@ use Nette\DI\ContainerLoader;
 use Nettrine\DBAL\DI\DbalExtension;
 use Nettrine\ORM\DI\OrmExtension;
 use Nettrine\ORM\DI\OrmXmlExtension;
-use Tests\Nettrine\ORM\Cases\TestCase;
+use Tests\Toolkit\TestCase;
 
 final class OrmXmlExtensionTest extends TestCase
 {
 
-	public function testExtensionCanBeRegistered(): void
+	public function testExtension(): void
 	{
 		$loader = new ContainerLoader(TEMP_PATH, true);
 		$class = $loader->load(function (Compiler $compiler): void {
@@ -32,7 +32,7 @@ final class OrmXmlExtensionTest extends TestCase
 		/** @var Container $container */
 		$container = new $class();
 
-		self::assertInstanceOf(XmlDriver::class, $container->getService('orm.xml.xmlDriver'));
+		$this->assertInstanceOf(XmlDriver::class, $container->getService('orm.xml.xmlDriver'));
 	}
 
 }

--- a/tests/fixtures/DummyConfiguration.php
+++ b/tests/fixtures/DummyConfiguration.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Tests\Nettrine\ORM\Fixtures;
+namespace Tests\Fixtures;
 
 use Doctrine\ORM\Configuration;
 

--- a/tests/fixtures/DummyEntityManagerDecorator.php
+++ b/tests/fixtures/DummyEntityManagerDecorator.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Tests\Nettrine\ORM\Fixtures;
+namespace Tests\Fixtures;
 
 use Nettrine\ORM\EntityManagerDecorator;
 

--- a/tests/toolkit/TestCase.php
+++ b/tests/toolkit/TestCase.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Tests\Nettrine\ORM\Cases;
+namespace Tests\Toolkit;
 
 use Mockery;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;


### PR DESCRIPTION
- Require PHP ^7.2
- Test against PHP 7.2-8.0
- Support new yummy nette/schema. Refactor configuration to allow pass any key needed.
- Refactor tests.
- Refactor cache creating.

----

```
{
  "require": {
    "nettrine/orm": "^0.5.0"
  }
}
```