### PR TITLE
nettrine/dbal dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "nette/di": "~3.0.0",
     "nette/utils": "~3.0.1",
     "symfony/console": "^4.2.5",
-    "nettrine/dbal": "^0.4.0 || ^0.5.0",
+    "nettrine/dbal": "^0.5.0 || ^0.6.0",
     "doctrine/orm": "^2.6.3",
     "doctrine/cache": "^1.8.0",
     "doctrine/annotations": "^1.6.1"


### PR DESCRIPTION
Solves Problem
      - Installation request for nettrine/orm dev-master -> satisfiable by nettrine/orm[dev-master].
      - nettrine/orm dev-master requires nettrine/dbal ^0.4.0 || ^0.5.0 -> no matching package found.