### PR TITLE
Remove inner orm.entityManager service 

### DIFF
--- a/src/DI/OrmExtension.php
+++ b/src/DI/OrmExtension.php
@@ -150,13 +150,10 @@ final class OrmExtension extends AbstractExtension
 		}
 
 		// Entity Manager
-		$original = $builder->addDefinition($this->prefix('entityManager'))
-			->setType(DoctrineEntityManager::class)
-			->setFactory(DoctrineEntityManager::class . '::create', [
-				$builder->getDefinitionByType(Connection::class), // Nettrine/DBAL
-				$this->prefix('@configuration'),
-			])
-			->setAutowired(false);
+		$original = new Statement(DoctrineEntityManager::class . '::create', [
+			$builder->getDefinitionByType(Connection::class), // Nettrine/DBAL
+			$this->prefix('@configuration'),
+		]);
 
 		// Entity Manager Decorator
 		$builder->addDefinition($this->prefix('entityManagerDecorator'))


### PR DESCRIPTION
So it resets properly when calling ManagerRegistry::resetManager.

I hope the test is OK, I did not know how to test this properly.

Closes #58 