### PR TITLE
Readme: fix typo in config

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -114,7 +114,7 @@ extensions:
   console: Contributte\Console\DI\ConsoleExtension(%consoleMode%)
 
   nettrine.orm: Nettrine\ORM\DI\OrmExtension
-  nettrine.orm.console: Nettrine\ORM\DI\OrmConsoleExtension(%consoleMode)
+  nettrine.orm.console: Nettrine\ORM\DI\OrmConsoleExtension(%consoleMode%)
 ```
 
 Since this moment when you type `bin/console`, there'll be registered commands from Doctrine DBAL.


### PR DESCRIPTION
Probably the smallest typo I've ever seen. I've used a lot of F words.

Missing percentage sign generates `Service of type 'Symfony\Component\Console\Application' not found.` error.

Credit goes to Jakub Vrchota.