### PR TITLE
Change validation rules for entityNamespaces

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -133,7 +133,7 @@ nettrine.orm:
     autoGenerateProxyClasses: <boolean>
     proxyNamespace: <string>
     metadataDriverImpl: <service>
-    entityNamespaces: <string[]>
+    entityNamespaces: <mixed[]>
     customStringFunctions: <mixed[]>
     customNumericFunctions: <mixed[]>
     customDatetimeFunctions: <mixed[]>

--- a/src/DI/OrmExtension.php
+++ b/src/DI/OrmExtension.php
@@ -37,7 +37,7 @@ final class OrmExtension extends AbstractExtension
 				'autoGenerateProxyClasses' => Expect::anyOf(Expect::int(), Expect::bool(), Expect::type(Statement::class))->default(AbstractProxyFactory::AUTOGENERATE_FILE_NOT_EXISTS),
 				'proxyNamespace' => Expect::string('Nettrine\Proxy')->nullable(),
 				'metadataDriverImpl' => Expect::string(),
-				'entityNamespaces' => Expect::listOf('string'),
+				'entityNamespaces' => Expect::array(),
 				'customStringFunctions' => Expect::array(),
 				'customNumericFunctions' => Expect::array(),
 				'customDatetimeFunctions' => Expect::array(),


### PR DESCRIPTION
Just a little change in config validation for entityNamespaces. Doctrine takes namespaces as a tuples of ['alias' => 'namespace']. You can't specify just a namespace without the alias.

```php
/**
* Adds a namespace under a certain alias.
*
* @param string $alias
* @param string $namespace
*
* @return void
*/
public function addEntityNamespace($alias, $namespace)
{
    $this->_attributes['entityNamespaces'][$alias] = $namespace;
}
```

[Doctrine configurator source code](https://github.com/doctrine/orm/blob/4fae126459d7deb6cb2877fc0c0f8ecfa4658516/lib/Doctrine/ORM/Configuration.php#L173-L184)