### PR TITLE
Stop using deprecated Doctrine\Common\Persistence\...

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -11,7 +11,7 @@ namespace PHPSTORM_META {
 	override(\Doctrine\ORM\EntityManagerInterface::getReference(0), map([
 		'' => '@',
 	]));
-	override(\Doctrine\Common\Persistence\ObjectManager::getRepository(0), map([
+	override(\Doctrine\Persistence\ObjectManager::getRepository(0), map([
 		'' => '@',
 	]));
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,5 @@
 parameters:
 	ignoreErrors:
 		# We will replace it once, for sure
-		- '#Fetching class constant .+ of deprecated class Doctrine\\Common\\Proxy\\AbstractProxyFactory.+#'
 		- '#Fetching class constant .+ of deprecated class Doctrine\\ORM\\Tools\\Console\\Command\\(GenerateEntities|GenerateRepositories)Command.+#'
 		- '#Fetching class constant .+ of deprecated class Doctrine\\ORM\\Proxy\\Proxy.+#'

--- a/src/DI/AbstractExtension.php
+++ b/src/DI/AbstractExtension.php
@@ -3,8 +3,8 @@
 namespace Nettrine\ORM\DI;
 
 use Contributte\DI\Extension\CompilerExtension;
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\ORM\Configuration;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Nette\DI\Definitions\ServiceDefinition;
 use Nettrine\ORM\Exception\Logical\InvalidStateException;
 use stdClass;

--- a/src/DI/OrmAnnotationsExtension.php
+++ b/src/DI/OrmAnnotationsExtension.php
@@ -2,7 +2,7 @@
 
 namespace Nettrine\ORM\DI;
 
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Nette\Schema\Expect;
 use Nette\Schema\Schema;
 use Nettrine\ORM\Mapping\AnnotationDriver;

--- a/src/DI/OrmExtension.php
+++ b/src/DI/OrmExtension.php
@@ -2,12 +2,12 @@
 
 namespace Nettrine\ORM\DI;
 
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Common\Proxy\AbstractProxyFactory;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager as DoctrineEntityManager;
 use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Nette\DI\Definitions\Statement;
 use Nette\DI\Helpers;
 use Nette\Schema\Expect;

--- a/src/ManagerRegistry.php
+++ b/src/ManagerRegistry.php
@@ -2,12 +2,12 @@
 
 namespace Nettrine\ORM;
 
-use Doctrine\Common\Persistence\AbstractManagerRegistry;
-use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Proxy\Proxy;
+use Doctrine\Persistence\AbstractManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
 use Nette\DI\Container;
 
 class ManagerRegistry extends AbstractManagerRegistry


### PR DESCRIPTION
Hey.
These classes are deprecated since `doctrine/persistence` v1.3 and they removed them in `doctrine/persistence` v2.
For that reason it stoped working with `doctrine/orm` v2.7.3 as it allows to install `doctrine/persistence` v2, this should fix it.

As it failed on test with `--prefer-lowest` I added `doctrine/persistence` in ^1.3 as dependency.
Another way is to require `doctrine/orm` ^2.7.0 instead of ^2.6.3.