### PR TITLE
Update annotations readme

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -227,11 +227,12 @@ extensions:
   nettrine.annotations: Nettrine\Annotations\DI\AnnotationsExtension
 ```
 
-You will also appreciate ORM => Annotations bridge, use `OrmAnnotationsExtension`. This is the default configuration, it uses an autowired cache driver.
+You will also appreciate ORM => Annotations bridge, use `OrmAnnotationsExtension`. This is the default configuration, it uses an autowired cache driver. Please note that `OrmAnnotationsExtension` must be registered after `AnnotationsExtension`.
 
 ```yaml
 extensions:
   nettrine.orm: Nettrine\ORM\DI\OrmExtension
+  nettrine.annotations: Nettrine\Annotations\DI\AnnotationsExtension
   nettrine.orm.annotations: Nettrine\ORM\DI\OrmAnnotationsExtension
 
 nettrine.orm.annotations:


### PR DESCRIPTION
Hello,

after updating to version 0.7, it took me 20 minutes to figure out, that i was registering OrmAnnotationsExtension before AnnotationsExtension and it was throwing an exception here https://github.com/nettrine/orm/blob/master/src/DI/OrmAnnotationsExtension.php#L42 I did small change in docs, maybe it could save someones time :) 