### PR TITLE
Docs: clarify migration from removed ORM split extensions

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -5,7 +5,6 @@ Integration of [Doctrine ORM](https://www.doctrine-project.org/projects/orm.html
 ## Content
 
 - [Installation](#installation)
-- [Migration from legacy extensions](#migration-from-legacy-extensions)
 - [Configuration](#configuration)
   - [Minimal configuration](#minimal-configuration)
   - [Advanced configuration](#advanced-configuration)
@@ -51,44 +50,6 @@ extensions:
 
 > [!NOTE]
 > This is just **ORM**, for **DBAL** please use [nettrine/dbal](https://github.com/contributte/doctrine-dbal).
-
-### Migration from legacy extensions
-
-> [!IMPORTANT]
-> Since `v0.10`, `nettrine/orm` uses only `Nettrine\ORM\DI\OrmExtension`.
-> Legacy split extensions were removed:
->
-> - `nettrine.orm.cache`
-> - `nettrine.orm.attributes`
-> - `nettrine.orm.xml`
-> - `nettrine.orm.annotations`
-> - `nettrine.orm.console`
-
-Use `nettrine.orm.managers.<name>` for cache, mapping, and manager configuration.
-
-```neon
-# before (removed)
-extensions:
-  nettrine.orm: Nettrine\ORM\DI\OrmExtension
-  nettrine.orm.cache: Nettrine\ORM\DI\OrmCacheExtension
-
-nettrine.orm.cache:
-  defaultDriver: @cache
-
-# now
-extensions:
-  nettrine.orm: Nettrine\ORM\DI\OrmExtension
-
-nettrine.orm:
-  managers:
-    default:
-      connection: default
-      defaultCache: @cache
-      mapping:
-        App:
-          directories: [%appDir%/Database]
-          namespace: App\Database
-```
 
 ## Configuration
 
@@ -1084,8 +1045,6 @@ vendor/bin/phpstan analyse -c phpstan.neon
 1. Are you looking for custom types? You can register custom types in DBAL, see [Nettrine DBAL](https://github.com/contributte/doctrine-dbal/blob/master/.docs/README.md#types).
 
 2. You have to configure entity mapping (for example attributes), otherwise you will get `It's a requirement to specify a Metadata Driver` error.
-
-3. If you are using old docs and see `Nettrine\ORM\DI\OrmCacheExtension` (or similar) service errors, remove legacy split extensions and configure everything under `nettrine.orm.managers`.
 
 ## Examples
 

--- a/.docs/README.md
+++ b/.docs/README.md
@@ -5,6 +5,7 @@ Integration of [Doctrine ORM](https://www.doctrine-project.org/projects/orm.html
 ## Content
 
 - [Installation](#installation)
+- [Migration from legacy extensions](#migration-from-legacy-extensions)
 - [Configuration](#configuration)
   - [Minimal configuration](#minimal-configuration)
   - [Advanced configuration](#advanced-configuration)
@@ -50,6 +51,44 @@ extensions:
 
 > [!NOTE]
 > This is just **ORM**, for **DBAL** please use [nettrine/dbal](https://github.com/contributte/doctrine-dbal).
+
+### Migration from legacy extensions
+
+> [!IMPORTANT]
+> Since `v0.10`, `nettrine/orm` uses only `Nettrine\ORM\DI\OrmExtension`.
+> Legacy split extensions were removed:
+>
+> - `nettrine.orm.cache`
+> - `nettrine.orm.attributes`
+> - `nettrine.orm.xml`
+> - `nettrine.orm.annotations`
+> - `nettrine.orm.console`
+
+Use `nettrine.orm.managers.<name>` for cache, mapping, and manager configuration.
+
+```neon
+# before (removed)
+extensions:
+  nettrine.orm: Nettrine\ORM\DI\OrmExtension
+  nettrine.orm.cache: Nettrine\ORM\DI\OrmCacheExtension
+
+nettrine.orm.cache:
+  defaultDriver: @cache
+
+# now
+extensions:
+  nettrine.orm: Nettrine\ORM\DI\OrmExtension
+
+nettrine.orm:
+  managers:
+    default:
+      connection: default
+      defaultCache: @cache
+      mapping:
+        App:
+          directories: [%appDir%/Database]
+          namespace: App\Database
+```
 
 ## Configuration
 
@@ -117,7 +156,7 @@ nettrine.orm:
       metadataCache: <class-string|service>
 
       secondLevelCache:
-        enable: <boolean>
+        enabled: <boolean>
         cache: <class-string|service>
         logger: <class-string|service>
         regions:
@@ -160,7 +199,7 @@ nettrine.orm:
 
 By default, this extension will try to autoconfigure itself.
 
-- **proxyDir**: `%tempDir%/proxies`, if `%tempDir%` is not defined,, you have to define it manually.
+- **proxyDir**: `%tempDir%/cache/doctrine/orm/proxies`, if `%tempDir%` is not defined, you have to define it manually.
 - **autoGenerateProxyClasses**: `%debugMode%`, if `%debugMode%` is not defined, you have to define it manually.
   - `0` means that the proxy classes must be generated manually.
   - `1` means that the proxy classes are generated automatically.
@@ -268,23 +307,23 @@ nettrine.orm:
       metadataCache: App\CacheService(%tempDir%/cache/doctrine/orm/metadata)
 ```
 
-Second level cache is a bit different. Be sure you know what you are doing, lear more in official [Doctrine documentation](https://www.doctrine-project.org/projects/doctrine-orm/en/3.3/reference/second-level-cache.html).
+Second level cache is a bit different. Be sure you know what you are doing, learn more in official [Doctrine documentation](https://www.doctrine-project.org/projects/doctrine-orm/en/3.3/reference/second-level-cache.html).
 
 ```neon
 nettrine.orm:
   managers:
     default:
-        secondLevelCache:
-          enable: true
-          cache: App\CacheService(%tempDir%/cache/doctrine/orm/slc)
-          logger: App\LoggerService()
-          regions:
-            region1:
-              lifetime: 3600
-              lockLifetime: 60
-            region2:
-              lifetime: 86000
-              lockLifetime: 60
+      secondLevelCache:
+        enabled: true
+        cache: App\CacheService(%tempDir%/cache/doctrine/orm/slc)
+        logger: App\LoggerService()
+        regions:
+          region1:
+            lifetime: 3600
+            lockLifetime: 60
+          region2:
+            lifetime: 86000
+            lockLifetime: 60
 ```
 
 If you like [`symfony/cache`](https://github.com/symfony/cache) you can use it as well.
@@ -424,7 +463,8 @@ It's a good practice if you have separated modules in your applications.
 
 namespace App\Model\DI;
 
-use Nette\DI\CompilerExtension;use Nettrine\ORM\DI\Helpers\MappingHelper;
+use Nette\DI\CompilerExtension;
+use Nettrine\ORM\DI\Helpers\MappingHelper;
 
 class DoctrineMappingExtension extends CompilerExtension
 {
@@ -971,7 +1011,7 @@ extensions:
 ### Console
 
 > [!TIP]
-> Doctrine DBAL needs Symfony Console to work. You can use `symfony/console` or [contributte/console](https://github.com/contributte/console).
+> Doctrine ORM console commands need Symfony Console. You can use `symfony/console` or [contributte/console](https://github.com/contributte/console).
 
 ```bash
 composer require contributte/console
@@ -984,7 +1024,7 @@ extensions:
   nettrine.orm: Nettrine\ORM\DI\OrmExtension
 ```
 
-Since this moment when you type `bin/console`, there'll be registered commands from Doctrine DBAL.
+Since this moment when you type `bin/console`, there'll be registered commands from Doctrine ORM.
 
 ![Console Commands](https://raw.githubusercontent.com/nettrine/orm/master/.docs/assets/console.png)
 
@@ -1044,6 +1084,8 @@ vendor/bin/phpstan analyse -c phpstan.neon
 1. Are you looking for custom types? You can register custom types in DBAL, see [Nettrine DBAL](https://github.com/contributte/doctrine-dbal/blob/master/.docs/README.md#types).
 
 2. You have to configure entity mapping (for example attributes), otherwise you will get `It's a requirement to specify a Metadata Driver` error.
+
+3. If you are using old docs and see `Nettrine\ORM\DI\OrmCacheExtension` (or similar) service errors, remove legacy split extensions and configure everything under `nettrine.orm.managers`.
 
 ## Examples
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to `nettrine/orm` are documented in this file.
+
+## Migration notes
+
+### v0.10
+
+- `nettrine/orm` uses only `Nettrine\ORM\DI\OrmExtension`.
+- Removed split extensions:
+  - `nettrine.orm.cache`
+  - `nettrine.orm.attributes`
+  - `nettrine.orm.xml`
+  - `nettrine.orm.annotations`
+  - `nettrine.orm.console`
+- Configure cache, mapping, and managers under `nettrine.orm.managers.<name>`.
+
+```neon
+# before (removed)
+extensions:
+  nettrine.orm: Nettrine\ORM\DI\OrmExtension
+  nettrine.orm.cache: Nettrine\ORM\DI\OrmCacheExtension
+
+nettrine.orm.cache:
+  defaultDriver: @cache
+
+# now
+extensions:
+  nettrine.orm: Nettrine\ORM\DI\OrmExtension
+
+nettrine.orm:
+  managers:
+    default:
+      connection: default
+      defaultCache: @cache
+      mapping:
+        App:
+          directories: [%appDir%/Database]
+          namespace: App\Database
+```


### PR DESCRIPTION
## Summary
- remove legacy split-extension migration content from package docs to keep `.docs/README.md` focused on current configuration only
- fix outdated snippets and option names so docs match current code (`secondLevelCache.enabled`, default `proxyDir` path, ORM console wording)
- add `CHANGELOG.md` with v0.10 migration notes for removed split extensions (`nettrine.orm.cache`, `nettrine.orm.attributes`, `nettrine.orm.xml`, `nettrine.orm.annotations`, `nettrine.orm.console`)

Closes #132