### PR TITLE
CI: replace phpdbg with php in coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ tests:
 
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary
- run coverage with \ instead of deprecated \
- keep the existing tester coverage target intact otherwise

## Motivation
- resolves contributte/contributte#73 for this repository

## Testing
- [x] make -n coverage
- [ ] full test suite