### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,5 +14,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.3"


### PR DESCRIPTION
## What changed
- Added `secrets: inherit` to `.github/workflows/coverage.yml` so the reusable coverage workflow receives the caller secrets.

## Why
- Finishes the issue 74 rollout for this repository so coverage jobs continue to work with the shared workflow setup tracked in contributte/contributte#74.